### PR TITLE
Improve SEO semantics and metadata

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -14,6 +14,7 @@ const bebasNeue = Bebas_Neue({
 });
 
 export const metadata = {
+  metadataBase: new URL("https://millenabarreto.com.br"),
   title: "Millena Barreto | Consultoria de Imagem e Estilo",
   description:
     "Consultoria de imagem e estilo personalizada. Descubra sua melhor versão com análise de coloração pessoal e styling individual.",

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -30,14 +30,16 @@ const Home = () => {
           `,
         }}
       />
-      <Hero />
-      <FixedMenu />
-      <Services />
-      <About />
-      <Work />
-      <Testimonial />
-      <Palestra />
-      <Contact />
+      <main id="inicio">
+        <Hero />
+        <FixedMenu />
+        <Services />
+        <About />
+        <Work />
+        <Testimonial />
+        <Palestra />
+        <Contact />
+      </main>
       <Footer />
     </>
   );

--- a/components/About.jsx
+++ b/components/About.jsx
@@ -22,7 +22,7 @@ const About = () => {
                   quality={100}
                   unoptimized={true}
                   priority
-                  alt=""
+                  alt="Consultora de imagem Millena Barreto sorrindo para a câmera"
                   className="object-cover rounded-tl-[8px] rounded-tr-[120px] min-h-[480px]"
                 />
               </div>
@@ -42,7 +42,7 @@ const About = () => {
                     src="/assets/about/shape-1.svg"
                     width={160}
                     height={160}
-                    alt=""
+                    alt="Selo decorativo giratório destacando experiência"
                   />
                 </motion.div>
                 <div className="absolute text-center text-white">

--- a/components/AnimatedText.jsx
+++ b/components/AnimatedText.jsx
@@ -31,8 +31,12 @@ const getLetter = (name) => {
   return letters;
 };
 
-const AnimatedText = ({ text, textStyles }) => {
-  return <div className={`${textStyles}`}>{getLetter(text)}</div>;
+const AnimatedText = ({ text, textStyles, ...props }) => {
+  return (
+    <div className={`${textStyles}`} {...props}>
+      {getLetter(text)}
+    </div>
+  );
 };
 
 export default AnimatedText;

--- a/components/Cards/Card.jsx
+++ b/components/Cards/Card.jsx
@@ -22,7 +22,7 @@ const Card = ({
                 src="/assets/journey/shape.svg"
                 width={16}
                 height={16}
-                alt=""
+                alt="Ícone decorativo da seção de jornada"
               />
               <h3 className="text-lg font-semibold text-primary">
                 {type === "experience"
@@ -46,7 +46,12 @@ const Card = ({
               ) : (
                 // render the logo for experience & education
                 <div className="relative w-[300px] h-[38px] xl:h-[44px]">
-                  <Image src={logoUrl} fill alt="" className="object-contain" />
+                  <Image
+                    src={logoUrl}
+                    fill
+                    alt={company || institution || name || "Logotipo da empresa"}
+                    className="object-contain"
+                  />
                 </div>
               )}
 

--- a/components/Contact.jsx
+++ b/components/Contact.jsx
@@ -24,7 +24,7 @@ const Contact = () => {
               className="object-cover"
               fill
               quality={100}
-              alt=""
+              alt="Cliente sorrindo após consultoria de estilo"
             />
           </div>
         </div>

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -64,7 +64,7 @@ const Hero = () => {
               src="/assets/hero/arrow.svg"
               width={160}
               height={160}
-              alt="Seta indicando destaque"
+              alt="Seta decorativa indicando destaque visual"
             />
           </div>
           {/* shape 1 */}
@@ -79,7 +79,7 @@ const Hero = () => {
                   src="assets/hero/shape-1.svg"
                   width={38}
                   height={38}
-                  alt=""
+                  alt="Detalhe geométrico complementar"
                 />
               }
               direction="left"
@@ -98,7 +98,7 @@ const Hero = () => {
                   src="assets/hero/shape-2.svg"
                   width={34}
                   height={34}
-                  alt=""
+                  alt="Elemento gráfico circular em movimento"
                 />
               }
               direction="right"
@@ -117,7 +117,7 @@ const Hero = () => {
                   src="assets/hero/shape-3.svg"
                   width={36}
                   height={36}
-                  alt=""
+                  alt="Ícone ornamental giratório"
                 />
               }
               direction="left"

--- a/components/Services.jsx
+++ b/components/Services.jsx
@@ -25,8 +25,11 @@ const services = [
 
 const Services = () => {
   return (
-    <section className="relative z-40" id="trabalhos">
+    <section className="relative z-40" id="trabalhos" aria-labelledby="servicos-heading">
       <div className="container mx-auto">
+        <h2 id="servicos-heading" className="sr-only">
+          Serviços de consultoria de imagem e estilo
+        </h2>
         <ul className="relative grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-[20px] -top-12 place-items-center lg:place-items-stretch">
           {services.map((service, index) => {
             return (
@@ -38,7 +41,7 @@ const Services = () => {
                   src={service.icon}
                   width={48}
                   height={48}
-                  alt=""
+                  alt={`Ícone de ${service.title.toLowerCase()}`}
                   className="mb-4"
                 />
                 <h3 className="text-[20px] text-primary font-semibold mb-3">

--- a/components/Testimonial.jsx
+++ b/components/Testimonial.jsx
@@ -60,11 +60,12 @@ const Testimonial = () => {
   }, [swiperRef]);
 
   return (
-    <div className="py-24 overflow-hidden">
+    <section className="py-24 overflow-hidden" id="depoimentos" aria-labelledby="depoimentos-heading">
       <div className="container mx-auto">
         <AnimatedText
           text="O que os clientes estão dizendo.."
           textStyles="h2 mb-[30px] xl:mb-[60px] text-center"
+          id="depoimentos-heading"
         />
         <div className="flex flex-col lg:flex-row gap-12">
           {/* slider info */}
@@ -122,7 +123,7 @@ const Testimonial = () => {
                         className="object-cover object-center"
                         quality={100}
                         fill
-                        alt=""
+                        alt={`Foto de ${slide.name} que avaliou a consultoria de imagem`}
                       />
                     </div>
                   </div>
@@ -132,7 +133,7 @@ const Testimonial = () => {
           </Swiper>
         </div>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/components/Work/Work.jsx
+++ b/components/Work/Work.jsx
@@ -35,13 +35,18 @@ const Work = () => {
   };
 
   return (
-    <section className="pt-24 min-h-[1000px]" id="trabalhos">
+    <section
+      className="pt-24 min-h-[1000px]"
+      id="trabalhos"
+      aria-labelledby="trabalhos-heading"
+    >
       <div className="container mx-auto">
         <Tabs defaultValue="todos" className="w-full flex flex-col">
           <div className="flex flex-col xl:flex-row items-center xl:items-start xl:justify-between mb-[30px]">
             <AnimatedText
               text="Meus trabalhos"
               textStyles="h2 mb-[30px] xl:mb-0"
+              id="trabalhos-heading"
             />
             {/* render tab triggers */}
             <TabsList className="max-w-max h-full mb-[30px] flex flex-col md:flex-row gap-4 md:gap-0">

--- a/components/Work/WorkItem.jsx
+++ b/components/Work/WorkItem.jsx
@@ -4,7 +4,11 @@ import { Badge } from "../ui/badge";
 
 const WorkItem = ({ href, category, img, title }) => {
   return (
-    <Link href="/" className="group">
+    <Link
+      href={href || "#trabalhos"}
+      className="group"
+      aria-label={`Ver detalhes de ${title}`}
+    >
       <div className="w-full h-[300px] p-8 rounded-[30px] flex items-center justify-center mb-6 relative overflow-hidden bg-[#f4f4f4]">
         <Badge className="bg-primary text-base z-40 absolute top-6 left-6 capitalize">
           {category}
@@ -15,7 +19,7 @@ const WorkItem = ({ href, category, img, title }) => {
           priority
           quality={100}
           className="object-cover group-hover:scale-105 transition-all duration-500"
-          alt=""
+          alt={title}
         />
       </div>
       <div className="flex items-center justify-center">


### PR DESCRIPTION
## Summary
- add metadataBase to support canonical and social URLs
- wrap homepage content in a main region and label key sections for better semantics
- provide descriptive alt text and accessible labels for service, portfolio, testimonial, and contact media

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b27a0aba083298ab171664cf799df)